### PR TITLE
Simplify filtering by getting rid of `TaskStatusFilter`

### DIFF
--- a/lib/extensions/task_date_extensions.dart
+++ b/lib/extensions/task_date_extensions.dart
@@ -3,11 +3,7 @@ import 'package:flutter/material.dart';
 
 extension DateTimeMapping on DateTime? {
   bool equalsToFilter(TaskDateFilter taskDateFilter) {
-    if (this == null) {
-      return taskDateFilter == TaskDateFilter.all;
-    }
     return switch (taskDateFilter) {
-      TaskDateFilter.all => true,
       TaskDateFilter.today => DateUtils.isSameDay(this, DateTime.now()),
       TaskDateFilter.yesterday => DateUtils.dateOnly(this!) ==
           DateUtils.dateOnly(DateUtils.addDaysToDate(DateTime.now(), -1)),
@@ -17,10 +13,10 @@ extension DateTimeMapping on DateTime? {
   }
 }
 
-extension TaskDateFilterMapping on TaskDateFilter {
+extension TaskDateFilterMapping on TaskDateFilter? {
   String mapToText() {
     return switch (this) {
-      TaskDateFilter.all => 'All',
+      null => 'All',
       TaskDateFilter.yesterday => 'Yesterday',
       TaskDateFilter.today => 'Today',
       TaskDateFilter.tomorrow => 'Tomorrow',

--- a/lib/extensions/task_status_extensions.dart
+++ b/lib/extensions/task_status_extensions.dart
@@ -1,5 +1,4 @@
 import 'package:dutask/models/task_model.dart';
-import 'package:dutask/providers/filtered_tasks_provider.dart';
 import 'package:flutter/material.dart';
 
 extension TaskStatusMapping on TaskStatus {
@@ -11,25 +10,12 @@ extension TaskStatusMapping on TaskStatus {
     };
   }
 
-  String mapToText() {
-    return switch (this) {
-      TaskStatus.active => 'Active',
-      TaskStatus.started => 'Started',
-      TaskStatus.completed => 'Completed',
-    };
-  }
-
   IconData mapToIcon() {
     return switch (this) {
       TaskStatus.active => Icons.radio_button_unchecked,
       TaskStatus.started => Icons.autorenew,
       TaskStatus.completed => Icons.check,
     };
-  }
-
-  bool equalsToFilter(TaskStatusFilter taskStatusFilter) {
-    if (taskStatusFilter == TaskStatusFilter.all) return true;
-    return taskStatusFilter.name == name;
   }
 
   TaskStatus toggle() {
@@ -41,23 +27,23 @@ extension TaskStatusMapping on TaskStatus {
   }
 }
 
+extension TaskStatusMapping2 on TaskStatus? {
+  String mapToText() {
+    return switch (this) {
+      null => 'All',
+      TaskStatus.active => 'Active',
+      TaskStatus.started => 'Started',
+      TaskStatus.completed => 'Completed',
+    };
+  }
+}
+
 extension TaskStatusBoolToggling on bool? {
   bool? toggle() {
     return switch (this) {
       false => null,
       null => true,
       true => false,
-    };
-  }
-}
-
-extension TaskStatusFilterMapping on TaskStatusFilter {
-  String mapToText() {
-    return switch (this) {
-      TaskStatusFilter.all => 'All',
-      TaskStatusFilter.active => 'Active',
-      TaskStatusFilter.started => 'Started',
-      TaskStatusFilter.completed => 'Completed',
     };
   }
 }

--- a/lib/providers/filtered_tasks_provider.dart
+++ b/lib/providers/filtered_tasks_provider.dart
@@ -1,15 +1,12 @@
 import 'package:dutask/models/task_model.dart';
 import 'package:dutask/providers/tasks_provider.dart';
 import 'package:dutask/extensions/task_date_extensions.dart';
-import 'package:dutask/extensions/task_status_extensions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-enum TaskStatusFilter { all, started, active, completed }
+enum TaskDateFilter { yesterday, today, tomorrow }
 
-enum TaskDateFilter { all, yesterday, today, tomorrow }
-
-final taskStatusFilter = StateProvider((ref) => TaskStatusFilter.all);
-final taskDateFilter = StateProvider((ref) => TaskDateFilter.all);
+final taskStatusFilter = StateProvider<TaskStatus?>((ref) => null);
+final taskDateFilter = StateProvider<TaskDateFilter?>((ref) => null);
 
 final filteredTasks = Provider<List<TaskModel>>((ref) {
   final statusFilter = ref.watch(taskStatusFilter);
@@ -18,7 +15,7 @@ final filteredTasks = Provider<List<TaskModel>>((ref) {
 
   return tasks
       .where((task) =>
-          task.status.equalsToFilter(statusFilter) &&
-          task.dueDate.equalsToFilter(dateFilter))
+          (statusFilter == null || task.status == statusFilter) &&
+          (dateFilter == null || task.dueDate.equalsToFilter(dateFilter)))
       .toList();
 });

--- a/lib/widgets/filter_chips_bar.dart
+++ b/lib/widgets/filter_chips_bar.dart
@@ -1,3 +1,4 @@
+import 'package:dutask/models/task_model.dart';
 import 'package:dutask/providers/filtered_tasks_provider.dart';
 import 'package:dutask/extensions/task_date_extensions.dart';
 import 'package:dutask/extensions/task_status_extensions.dart';
@@ -19,15 +20,17 @@ class FilterChipsBar extends ConsumerWidget {
     final selectedDateFilterValue = ref.watch(taskDateFilter);
 
     final List<FilterChip> filterChips = switch (selectedFilter) {
-      FilterType.status => TaskStatusFilter.values.map((filter) {
-          return FilterChip(
-            label: Text(filter.mapToText()),
-            selected: selectedStatusFilterValue == filter,
-            onSelected: (_) =>
-                ref.read(taskStatusFilter.notifier).state = filter,
-          );
-        }).toList(),
-      FilterType.dueDate => TaskDateFilter.values.map((filter) {
+      FilterType.status => [null, ...TaskStatus.values].map(
+          (filter) {
+            return FilterChip(
+              label: Text(filter.mapToText()),
+              selected: selectedStatusFilterValue == filter,
+              onSelected: (_) =>
+                  ref.read(taskStatusFilter.notifier).state = filter,
+            );
+          },
+        ).toList(),
+      FilterType.dueDate => [null, ...TaskDateFilter.values].map((filter) {
           return FilterChip(
             label: Text(filter.mapToText()),
             selected: selectedDateFilterValue == filter,

--- a/lib/widgets/filter_settings_drawer.dart
+++ b/lib/widgets/filter_settings_drawer.dart
@@ -35,10 +35,8 @@ class FilterSettingsDrawer extends ConsumerWidget {
                     onChanged: (onChangedFilter) {
                       ref.read(selectedQuickFilter.notifier).state =
                           onChangedFilter!;
-                      ref.read(taskStatusFilter.notifier).state =
-                          TaskStatusFilter.all;
-                      ref.read(taskDateFilter.notifier).state =
-                          TaskDateFilter.all;
+                      ref.read(taskStatusFilter.notifier).state = null;
+                      ref.read(taskDateFilter.notifier).state = null;
                     },
                     title: Text(filter.mapToText()),
                   );


### PR DESCRIPTION
Hello Lello!

This PR just simplify things (the net change removes lines of code). I just wanted to remove this ugly comparison:

```dart
bool equalsToFilter(TaskStatusFilter taskStatusFilter) {
    if (taskStatusFilter == TaskStatusFilter.all) return true;
    return taskStatusFilter.name == name;
}
```

In order to do it I decided to remove also `TaskStatusFilter`. Why? It is just the same thing as `TaskStatus` except for `All` and we don't want to write things twice. So we could think the `All` filter as a `null` filter (we don't filter with `All`). So the filter becomes just a check on `TaskStatus?`. If it is `null`, then `All` is selected.

Take a look and let me know what you think.

Keep going! :)